### PR TITLE
Deploy steps

### DIFF
--- a/.github/workflows/go-deploy.yml
+++ b/.github/workflows/go-deploy.yml
@@ -20,4 +20,22 @@ jobs:
 
     - name: Create zip files for release
       run: make compress
+    
+    - name: Create Github Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.run_number }}
+        release_name: Release ${{ github.run_number }}
+        draft: false
+        prerelease: false
 
+    - name: Upload Release Assets
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./build/*

--- a/.github/workflows/go-deploy.yml
+++ b/.github/workflows/go-deploy.yml
@@ -1,0 +1,23 @@
+name: Go Deploy
+
+on:
+  push:
+    branches: "*"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Create artifacts
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.22'
+
+    - name: Create binary artifacts
+      run: make build
+
+    - name: Create zip files for release
+      run: make compress
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,58 @@
+# Makefile for multiplatform Golang build
+
+# Binary name
+BINARY_NAME=gomboc
+
+# Build directory
+BUILD_DIR=build
+BIN_DIR=$(BUILD_DIR)/bin
+RELEASE_DIR=$(BUILD_DIR)/release
+
+# Version
+VERSION=1.0.0
+
+# Target platforms
+PLATFORMS=darwin linux windows
+
+WINDOWS_ARCHS=386 amd64
+DARWIN_ARCHS=amd64 arm64
+LINUX_ARCHS=386 amd64 arm arm64 ppc64 ppc64le mips mipsle mips64 mips64le
+
+WINDOWS_EXT=.exe
+DARWIN_EXT=.app
+LINUX_EXT=
+
+# Setup linker flags option for build that interoperate with variable names in your Go code
+LDFLAGS=-ldflags "-X main.Version=$(VERSION)"
+
+# Default target
+all: clean build
+
+# Builds the binary for all target platforms
+build: $(PLATFORMS)
+
+# Targets for each platform
+$(PLATFORMS):
+	@$(eval EXT=$($(shell echo $@ | tr '[:lower:]' '[:upper:]')_EXT))
+	@$(eval ARCHS=$($(shell echo $@ | tr '[:lower:]' '[:upper:]')_ARCHS))
+	@$(MAKE) --no-print-directory EXT=$(EXT) GOOS=$@ ARCHITECTURES="$(ARCHS)" build-target
+
+build-target:
+	@$(foreach arch,$(ARCHITECTURES), \
+		echo "Building $(BINARY_NAME)-$(GOOS)-$(VERSION)-$(arch)"; \
+		GOOS=$(GOOS) GOARCH=$(arch) go build $(LDFLAGS) -o \
+		'$(BIN_DIR)/$(BINARY_NAME)-$(GOOS)-$(VERSION)-$(arch)$(EXT)'; \
+	)
+
+compress:
+	$(shell mkdir -p $(RELEASE_DIR))
+	@$(foreach platform,$(PLATFORMS), \
+		zip -r $(RELEASE_DIR)/$(BINARY_NAME)-$(VERSION)-$(platform).zip $(BIN_DIR)/$(BINARY_NAME)-$(platform)-$(VERSION)*; \
+	)
+
+# Cleans up the build directory
+clean:
+	@rm -rf $(BUILD_DIR)/
+
+# Phony targets for make
+.PHONY: all build clean $(PLATFORMS) build-target

--- a/gomboc.go
+++ b/gomboc.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"gomboc/cmd"
+	"os"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+)
+
+func setDefaultZeroLogger() {
+	zerolog.SetGlobalLevel(zerolog.TraceLevel)
+	zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
+
+	log.Logger = zerolog.New(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.DateTime})
+	log.Logger = log.Logger.With().Timestamp().Caller().Logger()
+}
+
+func main() {
+	setDefaultZeroLogger() // set the global zloggger configuration
+
+	cmd.Execute()
+}


### PR DESCRIPTION
Description
========
Introduces the deployment steps for multiplatform and multiarchitecture. The Makefile commands can alternate between clean (to clean the build folder), build (to build the artifacts) and compress (to compress the releases).

- [x] Create a makefile;
- [x] Start GitHub workflow;
- [x] Add a deploy step;
- [x] Upload release files;

Changes
=========
- inserted a makefile.