### PR TITLE
Prevent crash when no toml

### DIFF
--- a/environ/environ.go
+++ b/environ/environ.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/BurntSushi/toml"
+	"github.com/rs/zerolog/log"
 )
 
 const CONF_FILE_NAME = "gomboc.toml"
@@ -67,7 +68,10 @@ func GombocConfigLoader() GombocConfig {
 	data, err := os.ReadFile(filepath)
 
 	if err != nil {
-		panic("Unable to open configuration file " + filepath)
+		log.Error().Msgf("The file '%s' was not found. Skipped.", filepath)
+		config = GombocConfig{}
+
+		return config
 	}
 
 	_, err = toml.Decode(string(data), &config)


### PR DESCRIPTION
Description
===========
Skip function `GombocConfigLoader` when configuration file was not found. This change prevents a not necessary crash.

Changes
=======
- update function `GombocConfigLoader` at environ.go.